### PR TITLE
https://github.com/jovotech/jovo-sample-podcast-player/issues/3

### DIFF
--- a/src/episodes.json
+++ b/src/episodes.json
@@ -5,7 +5,7 @@
     },
     {
         "title": "John Kelvie CEO of Bespoken Discusses How Voice App Testing is Different",
-        "url": "https://traffic.libsyn.com/voicebot/John_Kelvie_CEO_of_Bespoken_Talks_Voice_App_Testing_-_Voicebot_Podcast_Ep_55"
+        "url": "https://traffic.libsyn.com/voicebot/John_Kelvie_CEO_of_Bespoken_Talks_Voice_App_Testing_-_Voicebot_Podcast_Ep_55.mp3"
     },
     {
         "title": "Shane Mac CEO of Assist Says The Talking Internet is Here",


### PR DESCRIPTION
Ep_55 was missing .mp3 suffix. No wonder it wouldn't play.